### PR TITLE
feature: add @obsolete decorator

### DIFF
--- a/src/api/v1/dtos/resources/Health.ts
+++ b/src/api/v1/dtos/resources/Health.ts
@@ -1,6 +1,5 @@
 import {
   Description,
-  Required,
   Resource,
   UnixTimestamp,
 } from "infrastructure/openapi/decorators";

--- a/src/infrastructure/openapi/decorators/Definitions.ts
+++ b/src/infrastructure/openapi/decorators/Definitions.ts
@@ -28,6 +28,7 @@ export type PropertyDefinition = {
   description?: string;
   example?: string | number | boolean;
   required?: boolean;
+  deprecated?: boolean;
 };
 
 export type TagDefinition = {
@@ -50,6 +51,7 @@ export type RouteDefinition = {
   responses?: ResponseDefinition[];
   contentTypes?: MIMETypes[];
   description?: string;
+  deprecated?: boolean;
 };
 
 export type ResponseSchema = {

--- a/src/infrastructure/openapi/decorators/Obsolete.ts
+++ b/src/infrastructure/openapi/decorators/Obsolete.ts
@@ -1,0 +1,29 @@
+import Action from "./Action";
+import Property from "./Property";
+
+/**
+ * Deprecated decorator for properties and controller actions.
+ *
+ * @param {string} description
+ * @return {*}  {(PropertyDecorator | MethodDecorator)}
+ */
+ function Obsolete(): PropertyDecorator;
+ function Obsolete(): MethodDecorator {
+   return (
+     target: Object,
+     propertyKey: string | symbol,
+     descriptor: PropertyDescriptor
+   ): void => {
+     const isForRoute = descriptor != null;
+ 
+     if (isForRoute) {
+       Action({ deprecated: true })(target, propertyKey, descriptor);
+       return;
+     }
+ 
+     Property({ deprecated: true })()(target, propertyKey);
+   };
+ }
+
+ 
+export default Obsolete;

--- a/src/infrastructure/openapi/decorators/Parameter.ts
+++ b/src/infrastructure/openapi/decorators/Parameter.ts
@@ -43,12 +43,9 @@ const Parameter =
           const property = properties.find((p) => p.name === key);
   
           return {
+            ...property,
             name: key,
-            required: property?.required,
             type: property?.type || "string",
-            format: property?.format,
-            description: property?.description,
-            example: property?.example,
           };
         }),
       };

--- a/src/infrastructure/openapi/decorators/Responds.ts
+++ b/src/infrastructure/openapi/decorators/Responds.ts
@@ -40,10 +40,8 @@ const Responds = <R>(
           return {
             ...schema,
             [key]: {
+              ...property,
               type: property?.type || "string",
-              format: property?.format,
-              example: property?.example,
-              description: property?.description,
             },
           };
         }, {}),

--- a/src/infrastructure/openapi/decorators/index.ts
+++ b/src/infrastructure/openapi/decorators/index.ts
@@ -44,6 +44,7 @@ export { default as UnixTimestamp } from "./UnixTimestamp";
 export { default as Seconds } from "./Seconds";
 export { default as Example } from "./Example";
 export { default as Required } from "./Required";
+export { default as Obsolete } from "./Obsolete";
 
 
 // Extra info for API documentation

--- a/tests/github-issues/14/issue-14.ts
+++ b/tests/github-issues/14/issue-14.ts
@@ -10,20 +10,25 @@ describe("github issues > #14 Add @Required() decorator to document that a param
     @Required()
     public requiredProperty: unknown;
 
+    @Required()
+    public otherRequiredProperty: unknown;
+
     public optionalProperty: unknown;
   }
 
-  it("should have captured metadata of the required property only", () => {
+  it("should capture metadata of the required properties only", () => {
     const properties: PropertyDefinition[] = Reflect.getMetadata(
       "properties",
       Target
     );
 
-    expect(properties).to.have.lengthOf(1);
-    expect(properties.find((p) => p.name == "requiredProperty")).to.not.be.null;
+    expect(properties).to.have.lengthOf(2);
+    expect(properties.find((p) => p.name == "requiredProperty")).to.not.be.undefined;
+    expect(properties.find((p) => p.name == "otherRequiredProperty")).to.not.be.undefined;
+    expect(properties.find((p) => p.name == "optionalProperty")).to.be.undefined;
   });
 
-  it("should have set marked 'requiredProperty' as required", () => {
+  it("should mark required property as required", () => {
     const properties: PropertyDefinition[] = Reflect.getMetadata(
       "properties",
       Target

--- a/tests/github-issues/29/issue-29.ts
+++ b/tests/github-issues/29/issue-29.ts
@@ -1,0 +1,42 @@
+import "reflect-metadata";
+import { expect } from "chai";
+import {
+  Obsolete,
+  PropertyDefinition,
+  RouteDefinition,
+} from "infrastructure/openapi/decorators";
+
+describe("github issues > #29 Add @Obsolete() decorator to document that a property or endpoint is deprecated.", () => {
+  class Resource {
+    @Obsolete()
+    public obsoleteProperty: unknown;
+
+    public justAProperty: unknown;
+  }
+
+  class Controller {
+    @Obsolete()
+    public someAction(): void {
+      // do stuff
+    }
+  }
+
+  it("should mark property as obsolete", () => {
+    const properties: PropertyDefinition[] = Reflect.getMetadata(
+      "properties",
+      Resource
+    );
+
+    const property = properties.find((p) => p.name === "obsoleteProperty");
+    expect(property).to.not.be.undefined;
+    expect(property?.deprecated).to.be.true;
+  });
+
+  it("should mark action as obsolete", () => {
+    const routes: RouteDefinition[] = Reflect.getMetadata("routes", Controller);
+
+    const property = routes.find((p) => p.name === "someAction");
+    expect(property).to.not.be.undefined;
+    expect(property?.deprecated).to.be.true;
+  });
+});


### PR DESCRIPTION
## Overview

### Type of change
*Content in the pull request. Choose all that apply.*

- [X] **New feature** (change which adds functionality)
- [ ] **Bug fix** (change which fixes an issue)
- [X] **Enhancement** (change which enhances the code in some way, a.k.a refactor)
- [ ] **Breaking change** (change which would cause existing functionality to not work as expected)
- [ ] **Dependecies** (change which adds or upgrade dependencies)
- [ ] **Documentation** (change which enhances the documentation)
- [X] **Automated tests** (change which enhances automated test suites)

Resolves: #29

### Summary
It was needed an easy way to document when an endpoint or property was deprecated.

### Motivation
Sometimes we're are forced to break the contract of an API because of new requirements, so it would be nice to have an easy way to document and express that to consumers.

### Dependencies
None

## How Has This Been Tested?

- [ ] Wrote automated tests to make sure the property's metadata included the right info.
- [ ] Visual testing of the documentation in the swagger UI.

### Steps to reproduce

**Wrote automated tests to make sure the property's metadata included the right info.**

1. `npm test -- --testMatch "**/*/issue-29.ts"`

**Visual testing of the documentation in the swagger UI.**

1. Use the @required() decorator in some param property.
2. Go to the swagger UI.
3. Look for your property.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
